### PR TITLE
#63 Safari Input Focus Fix

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -2,6 +2,7 @@ import type { Preview } from '@storybook/react';
 import React from 'react';
 
 import '../src/styles/globals.css';
+import Providers from '../src/utils/query/provider';
 
 const preview: Preview = {
   parameters: {
@@ -14,7 +15,11 @@ const preview: Preview = {
   },
   decorators: [
     (Story: any) => {
-      return <Story />;
+      return (
+        <Providers>
+          <Story />
+        </Providers>
+      );
     },
   ],
 };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": "20.x"
   },
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --hostname 0.0.0.0 --port 3000",
     "dev:https": "next dev --experimental-https",
     "build": "next build",
     "start": "next start",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
     <html lang='en'>
       <meta
         name='viewport'
-        content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no'
+        content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0'
       ></meta>
       <body>
         <Providers>

--- a/src/components/common/Input/ui/Input.tsx
+++ b/src/components/common/Input/ui/Input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
       <input
         type={type}
         className={cn(
-          'w-full flex bg-transparent typo-label1 font-medium text-gray-7 placeholder:text-gray-5 outline-none disabled:cursor-not-allowed disabled:opacity-50',
+          'w-full flex bg-transparent typo-input font-medium text-gray-7 placeholder:text-gray-5 outline-none disabled:cursor-not-allowed disabled:opacity-50',
           className,
         )}
         ref={ref}

--- a/src/components/manage/Response/CancelModal/CancelModal.stories.tsx
+++ b/src/components/manage/Response/CancelModal/CancelModal.stories.tsx
@@ -6,6 +6,11 @@ const meta: Meta<typeof CancelModal> = {
   title: 'Common/Modal/CancelModal',
   component: CancelModal,
   argTypes: {},
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+    },
+  },
 };
 
 export default meta;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -26,6 +26,14 @@
   }
 }
 
+/* 인풋 safari 홧대 이슈 수정 */
+@layer components {
+  .typo-input {
+    @apply origin-left scale-[0.875] typo-body;
+    -webkit-text-size-adjust: 100%;
+  }
+}
+
 @layer base {
   :root {
     --background: 0 0% 100%;


### PR DESCRIPTION
## 📖 관련 문서

#63 

## ✍🏻 변경사항:

- input typo class 수정
  - font-size : 16px; scale : 0.875; 로 수정하여 시각적으로 14px로 보이도록 적용 

## 🔍 확인할 목록

- [ ] : Input focus 확인

```
모바일 사파리에서 16px 미만의 사이즈에서는 zoom-in이 되는 이슈가 있습니다.
view-port에서 설정하는게 적용이 되지 않아 scale을 변경하는 방법을 사용했습니다.
```